### PR TITLE
Make link regex ignore other attributes

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -32,7 +32,7 @@ class Crawler():
 	marked = {}
 
 	# TODO also search for window.location={.*?}
-	linkregex = re.compile(b'<a href=[\'|"](.*?)[\'"].*?>')
+	linkregex = re.compile(b'<a [^>]*href=[\'|"](.*?)[\'"].*?>')
 
 	rp = None
 	response_code={}


### PR DESCRIPTION
Currently, if you have a link such as:

    <a class='hello' href='/about'>

then this link is missed.  This update the regex ensures these are
caught.