### PR TITLE
More robust link regex

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -36,7 +36,7 @@ class Crawler():
 	not_parseable_ressources = (".avi", ".mkv", ".mp4", ".jpg", ".jpeg", ".png", ".gif" ,".pdf", ".iso", ".rar", ".tar", ".tgz", ".zip", ".dmg", ".exe")
 
 	# TODO also search for window.location={.*?}
-	linkregex = re.compile(b'<a [^>]*href=[\'|"](.*?)[\'"].*?>')
+	linkregex = re.compile(b'<a [^>]*href=[\'|"](.*?)[\'"][^>]*?>')
 	imageregex = re.compile (b'<img [^>]*src=[\'|"](.*?)[\'"].*?>')
 
 	rp = None


### PR DESCRIPTION
This is a very minor, but this allows line breaks inside tags (which [is valid HTML](https://stackoverflow.com/a/29509224/2223706)).

For example, this will now be matched properly:
```html
<a href="www.example.com"
> hello </a>
```