### PR TITLE
add basic auth to enable crawling of password protected sites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# for PyCharm and venv
+.idea
+venv

--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ $ python3 main.py --domain https://blog.lesite.us --images --parserobots | xmlli
 $ python3 main.py --domain https://blog.lesite.us --num-workers 4
 ```
 
+#### with basic auth
+***You need to configure `username` and `password` in your `config.py` before***
+```
+$ python3 main.py --domain https://blog.lesite.us --auth
+```
+
 ## Docker usage
 
 #### Build the Docker image:

--- a/config.py
+++ b/config.py
@@ -9,3 +9,7 @@ xml_header = """<?xml version="1.0" encoding="UTF-8"?>
 xml_footer = "</urlset>"
 
 crawler_user_agent = 'Sitemap crawler'
+
+# if used with --auth you have to provide username and password here for basic auth
+username = "username"
+password = "password"

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ parser.add_argument('--skipext', action="append", default=[], required=False, he
 parser.add_argument('-n', '--num-workers', type=int, default=1, help="Number of workers if multithreading")
 parser.add_argument('--parserobots', action="store_true", default=False, required=False, help="Ignore file defined in robots.txt")
 parser.add_argument('--debug', action="store_true", default=False, help="Enable debug mode")
+parser.add_argument('--auth', action="store_true", default=False, help="Enable basic authorisation while crawling")
 parser.add_argument('-v', '--verbose', action="store_true", help="Enable verbose output")
 parser.add_argument('--output', action="store", default=None, help="Output file")
 parser.add_argument('--exclude', action="append", default=[], required=False, help="Exclude Url if contain")


### PR DESCRIPTION
Hi :)
I recently used your cool little crawler and added some handy features for myself and some work usecases.
we need to crawl basic auth protected sites from time to time which are not public yet. 
So I thought about adding it to your little tool as an handy option which might be useful in some cases or for some individuals.

kind regards