### PR TITLE
Add support for sitemap index

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ $ python3 main.py --domain https://blog.lesite.us --num-workers 4
 $ python3 main.py --domain https://blog.lesite.us --auth
 ```
 
+#### Output sitemap index file
+***Sitemaps with over 50,000 URLs should be split into an index file that points to sitemap files that each contain 50,000 URLs or fewer.  Outputting as an index requires specifying an output file.  An index will only be output if a crawl has more than 50,000 URLs:***
+```
+$ python3 main.py --domain https://blog.lesite.us --as-index --output sitemap.xml
+```
+
 ## Docker usage
 
 #### Build the Docker image:

--- a/config.py
+++ b/config.py
@@ -8,6 +8,11 @@ xml_header = """<?xml version="1.0" encoding="UTF-8"?>
 """
 xml_footer = "</urlset>"
 
+sitemapindex_header = """<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+"""
+sitemapindex_footer = "</sitemapindex>"
+
 crawler_user_agent = 'Sitemap crawler'
 
 # if used with --auth you have to provide username and password here for basic auth

--- a/crawler.py
+++ b/crawler.py
@@ -389,15 +389,14 @@ class Crawler:
 		# index:    zero-based index from which to start writing url strings contained in
 		#           self.url_strings_to_output
 		try:
-			sitemap_file = open(filename, 'w')
+			with open(filename, 'w') as sitemap_file:
+				start_index = index
+				end_index = (index + self.MAX_URLS_PER_SITEMAP)
+				sitemap_url_strings = self.url_strings_to_output[start_index:end_index]
+				self.write_sitemap_file(sitemap_file, sitemap_url_strings)
 		except:
 			logging.error("Could not open sitemap file that is part of index.")
 			exit(255)
-
-		start_index = index
-		end_index = (index + self.MAX_URLS_PER_SITEMAP)
-		sitemap_url_strings = self.url_strings_to_output[start_index:end_index]
-		self.write_sitemap_file(sitemap_file, sitemap_url_strings)
 
 	@staticmethod
 	def write_sitemap_file(file, url_strings):

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ parser.add_argument('--debug', action="store_true", default=False, help="Enable 
 parser.add_argument('--auth', action="store_true", default=False, help="Enable basic authorisation while crawling")
 parser.add_argument('-v', '--verbose', action="store_true", help="Enable verbose output")
 parser.add_argument('--output', action="store", default=None, help="Output file")
+parser.add_argument('--as-index', action="store_true", default=False, required=False, help="Outputs sitemap as index and multiple sitemap files if crawl results in more than 50,000 links (uses filename in --output as name of index file)")
 parser.add_argument('--exclude', action="append", default=[], required=False, help="Exclude Url if contain")
 parser.add_argument('--drop', action="append", default=[], required=False, help="Drop a string from the url")
 parser.add_argument('--report', action="store_true", default=False, required=False, help="Display a report")


### PR DESCRIPTION
As first mentioned in [this](https://github.com/c4software/python-sitemap/issues/59) issue, sitemaps over 50,000 URLs should be split into multiple sitemap files, with a single master index file pointing to all of the sitemap files.  This PR adds support for outputting a sitemap index and multiple sitemap files.

- Right now, `--output` is not a required parameter; but outputting an index and multiple sitemap files without writing them to files isn't quite sensible.  The index contains pointers to files, so what would be the contents of the index when no output file is specified?  Because of this, I'm currently requiring `--output` when using the new `--as-index` flag.

- In order to output an index, you have to include the `--as-index` flag.  If you don't include the `--as-index` flag, then the sitemap will be written to a single file, even if there are more than 50,000 URLs.  My thinking was this would maintain backward compatibility; presumably everyone using the library right now is happy with the output so why change it?  Another possibility would be to take this away as an option and just always write an index if there are more than 50,000 URLs, since this would be in line with the specification.  If we do go with this, we would likely need to make --output required due to the first bullet described above.