### PR TITLE
Fixes skipping pages accessed with ?p=

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -301,7 +301,7 @@ class Crawler:
 				continue
 			if domain_link != self.target_domain:
 				continue
-			if parsed_link.path in ["", "/"]:
+            		if parsed_link.path in ["", "/"] and parsed_link.query == '':
 				continue
 			if "javascript" in link:
 				continue


### PR DESCRIPTION
This might be a non-problem as I am basically using this code to grab all the webpages of a site and not concerned with a sitemap. But wordpress commonly uses queries in their URL to access different pages: `example.com/?p=1`. The current code skips over all these as their path is just '/'. This checks the query part of the parsed url as well. 