### PR TITLE
Exclude redirects from sitemap

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -1,22 +1,21 @@
 import asyncio
-import concurrent.futures
 import base64
-from collections import defaultdict
-from copy import copy
-import math
-
-import config
+import concurrent.futures
 import logging
-from urllib.parse import urljoin, urlunparse, urlsplit, urlunsplit
-
-import re
-from urllib.parse import urlparse
-from urllib.request import urlopen, Request
-from urllib.robotparser import RobotFileParser
-from datetime import datetime
-
+import math
 import mimetypes
 import os
+import re
+from collections import defaultdict
+from copy import copy
+from datetime import datetime
+from urllib.parse import urljoin, urlsplit, urlunsplit
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+from urllib.robotparser import RobotFileParser
+
+import config
+
 
 class IllegalArgumentError(ValueError):
 	pass

--- a/crawler.py
+++ b/crawler.py
@@ -260,7 +260,10 @@ class Crawler:
 		lastmod = ""
 		if date:
 			lastmod = "<lastmod>"+date.strftime('%Y-%m-%dT%H:%M:%S+00:00')+"</lastmod>"
-		url_string = "<url><loc>"+self.htmlspecialchars(url.geturl())+"</loc>" + lastmod + image_list + "</url>"
+		# Note: that if there was a redirect, `final_url` may be different than
+		#       `current_url`
+		final_url = response.geturl()
+		url_string = "<url><loc>"+self.htmlspecialchars(final_url)+"</loc>" + lastmod + image_list + "</url>"
 		self.url_strings_to_output.append(url_string)
 
 		# Found links


### PR DESCRIPTION
It seems redirects are not meant to be in the sitemap (see [second commit's message](https://github.com/c4software/python-sitemap/commit/bc7d769a3f6a807522a6b5bd98eddf486379f490) for citations).  So this prevents that.  

I also tacked on 2 minor cleanups: one for imports and one to use [`defaultdict`](https://docs.python.org/3/library/collections.html#collections.defaultdict), but let me know if you don't want those.