### PR TITLE
Sort URLs alphabetically

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Read a config file to set parameters:
   $ python main.py --domain https://blog.lesite.us --output sitemap.xml --verbose
   ```
 
+#### Disable sorting output:
+
+  ```
+  $ python main.py --domain https://blog.lesite.us --output sitemap.xml --no-sort
+  ```
+
+
 #### Enable Image Sitemap
 
 More informations here https://support.google.com/webmasters/answer/178636?hl=en

--- a/crawler.py
+++ b/crawler.py
@@ -66,7 +66,7 @@ class Crawler:
 	def __init__(self, num_workers=1, parserobots=False, output=None,
 				 report=False ,domain="", exclude=[], skipext=[], drop=[],
 				 debug=False, verbose=False, images=False, auth=False, as_index=False,
-				 sort_alphabetically=False, user_agent='*'):
+				 sort_alphabetically=True, user_agent='*'):
 		self.num_workers = num_workers
 		self.parserobots = parserobots
 		self.user_agent = user_agent

--- a/crawler.py
+++ b/crawler.py
@@ -66,7 +66,7 @@ class Crawler:
 	def __init__(self, num_workers=1, parserobots=False, output=None,
 				 report=False ,domain="", exclude=[], skipext=[], drop=[],
 				 debug=False, verbose=False, images=False, auth=False, as_index=False,
-				 user_agent='*'):
+				 sort_alphabetically=False, user_agent='*'):
 		self.num_workers = num_workers
 		self.parserobots = parserobots
 		self.user_agent = user_agent
@@ -81,6 +81,7 @@ class Crawler:
 		self.images     = images
 		self.auth       = auth
 		self.as_index   = as_index
+		self.sort_alphabetically = sort_alphabetically
 
 		if self.debug:
 			log_level = logging.DEBUG
@@ -137,6 +138,9 @@ class Crawler:
 				event_loop.close()
 
 		logging.info("Crawling has reached end of all found links")
+
+		if self.sort_alphabetically:
+			self.url_strings_to_output.sort()
 
 		self.write_sitemap_output()
 
@@ -423,7 +427,7 @@ class Crawler:
 
 	@staticmethod
 	def is_image(path):
-		mt,me = mimetypes.guess_type(path)
+		mt, me = mimetypes.guess_type(path)
 		return mt is not None and mt.startswith("image/")
 
 	def exclude_link(self,link):

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ parser.add_argument('--auth', action="store_true", default=False, help="Enable b
 parser.add_argument('-v', '--verbose', action="store_true", help="Enable verbose output")
 parser.add_argument('--output', action="store", default=None, help="Output file")
 parser.add_argument('--as-index', action="store_true", default=False, required=False, help="Outputs sitemap as index and multiple sitemap files if crawl results in more than 50,000 links (uses filename in --output as name of index file)")
-parser.add_argument('--sort-alphabetically', action="store_true", default=False, required=False, help="Sorts the output URLs alphabetically")
+parser.add_argument('--no-sort',  action="store_false", default=True, required=False, help="Disables sorting the output URLs alphabetically", dest='sort_alphabetically')
 parser.add_argument('--exclude', action="append", default=[], required=False, help="Exclude Url if contain")
 parser.add_argument('--drop', action="append", default=[], required=False, help="Drop a string from the url")
 parser.add_argument('--report', action="store_true", default=False, required=False, help="Display a report")

--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ parser.add_argument('--auth', action="store_true", default=False, help="Enable b
 parser.add_argument('-v', '--verbose', action="store_true", help="Enable verbose output")
 parser.add_argument('--output', action="store", default=None, help="Output file")
 parser.add_argument('--as-index', action="store_true", default=False, required=False, help="Outputs sitemap as index and multiple sitemap files if crawl results in more than 50,000 links (uses filename in --output as name of index file)")
+parser.add_argument('--sort-alphabetically', action="store_true", default=False, required=False, help="Sorts the output URLs alphabetically")
 parser.add_argument('--exclude', action="append", default=[], required=False, help="Exclude Url if contain")
 parser.add_argument('--drop', action="append", default=[], required=False, help="Drop a string from the url")
 parser.add_argument('--report', action="store_true", default=False, required=False, help="Display a report")


### PR DESCRIPTION
For large sitemaps, it's tough to see what changed when you rebuild it. That's because the URLs are not written in alphabetical order, so the diff doesn't work to see actual changes.

That's why the default behavior will now be to sort the output URLs alphabetically for generating the sitemap.
If you want to disable this, you can just add the flag:
```
python main.py --no-sort
```

Resolves #85