### PR TITLE
Add option to specify bot (user-agent) for robots.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ More informations here https://support.google.com/webmasters/answer/178636?hl=en
   $ python main.py --domain https://blog.lesite.us --output sitemap.xml --parserobots
   ```
 
+#### Use specific user-agent for robots.txt:
+
+  ```
+  $ python main.py --domain https://blog.lesite.us --output sitemap.xml --parserobots --user-agent Googlebot
+  ```
+
 #### Human readable XML
 
 ```

--- a/crawler.py
+++ b/crawler.py
@@ -65,9 +65,11 @@ class Crawler:
 
 	def __init__(self, num_workers=1, parserobots=False, output=None,
 				 report=False ,domain="", exclude=[], skipext=[], drop=[],
-				 debug=False, verbose=False, images=False, auth=False, as_index=False):
+				 debug=False, verbose=False, images=False, auth=False, as_index=False,
+				 user_agent='*'):
 		self.num_workers = num_workers
 		self.parserobots = parserobots
+		self.user_agent = user_agent
 		self.output 	= output
 		self.report 	= report
 		self.domain 	= domain
@@ -437,7 +439,7 @@ class Crawler:
 	def can_fetch(self, link):
 		try:
 			if self.parserobots:
-				if self.rp.can_fetch("*", link):
+				if self.rp.can_fetch(self.user_agent, link):
 					return True
 				else:
 					logging.debug ("Crawling of {0} disabled by robots.txt".format(link))

--- a/main.py
+++ b/main.py
@@ -1,16 +1,14 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import argparse
-import os
-
 import json
-
 import crawler
 
 parser = argparse.ArgumentParser(description='Python SiteMap Crawler')
 parser.add_argument('--skipext', action="append", default=[], required=False, help="File extension to skip")
 parser.add_argument('-n', '--num-workers', type=int, default=1, help="Number of workers if multithreading")
 parser.add_argument('--parserobots', action="store_true", default=False, required=False, help="Ignore file defined in robots.txt")
+parser.add_argument('--user-agent', action="store", default="*", help="Use the rules defined in robots.txt for a specific User-agent (i.e. Googlebot)")
 parser.add_argument('--debug', action="store_true", default=False, help="Enable debug mode")
 parser.add_argument('--auth', action="store_true", default=False, help="Enable basic authorisation while crawling")
 parser.add_argument('-v', '--verbose', action="store_true", help="Enable verbose output")


### PR DESCRIPTION
We want to add an option to run the script as a specific user-agent (Googlebot, for example), so it follows the specific rules for Googlebot instead of the general ones.

We allow this by add the flag `user-agent`:
```
python main.py --parserobots --user-agent Googlebot
```

Resolves #87 