### PR TITLE
Fix --parserobots blocking all links due to default User-Agent

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -9,6 +9,7 @@ import re
 from collections import defaultdict
 from copy import copy
 from datetime import datetime
+from urllib.error import HTTPError
 from urllib.parse import urljoin, urlsplit, urlunsplit
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
@@ -438,7 +439,25 @@ class Crawler:
 		robots_url = urljoin(self.domain, "robots.txt")
 		self.rp = RobotFileParser()
 		self.rp.set_url(robots_url)
-		self.rp.read()
+
+		# Fetch robots.txt with the same User-Agent used for crawling.
+		# RobotFileParser.read() uses urlopen() without a custom header, so
+		# it sends the default "Python-urllib/x.y" User-Agent, which some
+		# sites block (403) as a generic bot signature. That causes
+		# RobotFileParser to set disallow_all, blocking every discovered
+		# link even though the site's robots.txt actually allows crawling.
+		try:
+			request = Request(robots_url, headers={"User-Agent": config.crawler_user_agent})
+			response = urlopen(request)
+			raw = response.read()
+			self.rp.parse(raw.decode("utf-8").splitlines())
+		except HTTPError as err:
+			if err.code in (401, 403):
+				self.rp.disallow_all = True
+			elif 400 <= err.code < 500:
+				self.rp.allow_all = True
+		except Exception as e:
+			logging.debug(f"Could not fetch robots.txt: {e}")
 
 	def can_fetch(self, link):
 		try:


### PR DESCRIPTION
RobotFileParser.read() fetches robots.txt with urlopen() and no
custom headers, sending the default "Python-urllib/x.y" User-Agent.
Sites that block that generic UA signature (e.g. google.com) return
403 for robots.txt, which makes RobotFileParser set disallow_all,
causing every discovered link to be excluded even though the site's
actual robots.txt allows crawling. Fetch robots.txt with the same
User-Agent used for page requests and feed it to the parser manually,
replicating read()'s status-code handling.

Fixes #93

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AKDzcqdmXCLUWr875HBRg3