### PR TITLE
Add --respect-noindex to exclude noindex pages from the sitemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,11 @@ $ python3 main.py --domain https://blog.lesite.us --auth
 $ python3 main.py --domain https://blog.lesite.us --as-index --output sitemap.xml
 ```
 
-#### Exclude pages with a noindex meta tag
+#### Noindex / nofollow meta tags
 
-***Pages containing `<meta name="robots" content="noindex">` are excluded from the output sitemap. A `nofollow` directive on a page stops links found on that page from being followed, but doesn't exclude the page itself:***
+***By default, pages containing `<meta name="robots" content="noindex">` are excluded from the output sitemap (a `nofollow` directive on a page stops links found on that page from being followed, but doesn't exclude the page itself). Pass `--no-respect-noindex` to include noindex pages in the sitemap anyway:***
 ```
-$ python3 main.py --domain https://blog.lesite.us --output sitemap.xml --respect-noindex
+$ python3 main.py --domain https://blog.lesite.us --output sitemap.xml --no-respect-noindex
 ```
 
 #### Resume an interrupted crawl

--- a/README.md
+++ b/README.md
@@ -112,6 +112,13 @@ $ python3 main.py --domain https://blog.lesite.us --auth
 $ python3 main.py --domain https://blog.lesite.us --as-index --output sitemap.xml
 ```
 
+#### Exclude pages with a noindex meta tag
+
+***Pages containing `<meta name="robots" content="noindex">` are excluded from the output sitemap. A `nofollow` directive on a page stops links found on that page from being followed, but doesn't exclude the page itself:***
+```
+$ python3 main.py --domain https://blog.lesite.us --output sitemap.xml --respect-noindex
+```
+
 #### Resume an interrupted crawl
 ***Large crawls can take a long time and may get interrupted (Ctrl+C, a crash, a network drop). Pass `--resume` to periodically save crawl progress into `--output` itself, including on interrupt, instead of a separate file. Re-running the exact same command afterwards continues from that file instead of starting over:***
 ```

--- a/crawler.py
+++ b/crawler.py
@@ -80,7 +80,7 @@ class Crawler:
 				 report=False ,domain="", exclude=[], skipext=[], drop=[],
 				 debug=False, verbose=False, images=False, auth=False, as_index=False,
 				 fetch_iframes=False, sort_alphabetically=True, user_agent='*', resume=False,
-				 respect_noindex=False):
+				 respect_noindex=True):
 		self.num_workers   = num_workers
 		self.parserobots   = parserobots
 		self.user_agent    = user_agent

--- a/crawler.py
+++ b/crawler.py
@@ -63,6 +63,9 @@ class Crawler:
 	tagstripregex = re.compile(b'<[^>]+>')
 	iframeregex = re.compile (b'<iframe [^>]*src=[\'|"](.*?)[\'"].*?>')
 	baseregex = re.compile (b'<base [^>]*href=[\'|"](.*?)[\'"].*?>')
+	metaregex = re.compile(b'<meta\\s+[^>]*>', re.IGNORECASE)
+	metanameregex = re.compile(b'name=[\'"](.*?)[\'"]', re.IGNORECASE)
+	metacontentregex = re.compile(b'content=[\'"](.*?)[\'"]', re.IGNORECASE)
 
 	rp = None
 	response_code=defaultdict(int)
@@ -76,7 +79,8 @@ class Crawler:
 	def __init__(self, num_workers=1, parserobots=False, output=None,
 				 report=False ,domain="", exclude=[], skipext=[], drop=[],
 				 debug=False, verbose=False, images=False, auth=False, as_index=False,
-				 fetch_iframes=False, sort_alphabetically=True, user_agent='*', resume=False):
+				 fetch_iframes=False, sort_alphabetically=True, user_agent='*', resume=False,
+				 respect_noindex=False):
 		self.num_workers   = num_workers
 		self.parserobots   = parserobots
 		self.user_agent    = user_agent
@@ -94,6 +98,7 @@ class Crawler:
 		self.as_index      = as_index
 		self.sort_alphabetically = sort_alphabetically
 		self.resume        = resume
+		self.respect_noindex = respect_noindex
 
 		if self.debug:
 			log_level = logging.DEBUG
@@ -265,6 +270,11 @@ class Crawler:
 			msg = "".encode( )
 			date = None
 
+		# Meta robots directives (noindex/nofollow) found on the page, if enabled
+		meta_robots_directives = set()
+		if self.respect_noindex:
+			meta_robots_directives = self.get_meta_robots_directives(msg)
+
 		# Image sitemap enabled ?
 		image_list = ""
 		if self.images:
@@ -337,15 +347,18 @@ class Crawler:
 
 		# Only add to sitemap URLs with same domain as the site being indexed
 		if url.netloc == self.target_domain:
-			# Last mod fetched ?
-			lastmod = ""
-			if date:
-				lastmod = "<lastmod>"+date.strftime('%Y-%m-%dT%H:%M:%S+00:00')+"</lastmod>"
-			# Note: that if there was a redirect, `final_url` may be different than
-			#       `current_url`, and avoid not parseable content
-			final_url = response.geturl() if response is not None else current_url
-			url_string = "<url><loc>"+self.htmlspecialchars(final_url)+"</loc>" + lastmod + image_list + "</url>"
-			self.url_strings_to_output.append(url_string)
+			if "noindex" in meta_robots_directives:
+				logging.debug(f"Skipping {current_url} from sitemap, noindex meta tag found.")
+			else:
+				# Last mod fetched ?
+				lastmod = ""
+				if date:
+					lastmod = "<lastmod>"+date.strftime('%Y-%m-%dT%H:%M:%S+00:00')+"</lastmod>"
+				# Note: that if there was a redirect, `final_url` may be different than
+				#       `current_url`, and avoid not parseable content
+				final_url = response.geturl() if response is not None else current_url
+				url_string = "<url><loc>"+self.htmlspecialchars(final_url)+"</loc>" + lastmod + image_list + "</url>"
+				self.url_strings_to_output.append(url_string)
 		# If the URL has a different domain than the site being indexed, this was reached through an iframe
   		# In this case: if the base tag matches the site being indexed, then all relative URLs should be crawled.
 		else:
@@ -362,12 +375,33 @@ class Crawler:
 			current_url = base_url
 			url = parsed_base_url
 		
+		# A nofollow meta robots directive means links found on this page should
+		# not be followed, but doesn't affect pages reached through other links
+		if "nofollow" in meta_robots_directives:
+			logging.debug(f"Not following links on {current_url}, nofollow meta tag found.")
+			return
+
 		# Found links
 		self.find_links(msg, url, current_url)
 
 		if self.fetch_iframes:
 			self.find_links(msg, url, current_url, iframes=True)
 
+
+	def get_meta_robots_directives(self, msg):
+		# Collects the comma-separated values of <meta name="robots" content="..."> tags,
+		# e.g. {"noindex", "nofollow"} for <meta name="robots" content="noindex, nofollow">
+		directives = set()
+		for meta_tag in self.metaregex.findall(msg):
+			name_match = self.metanameregex.search(meta_tag)
+			if not name_match or name_match.group(1).decode("utf-8", errors="ignore").strip().lower() != "robots":
+				continue
+			content_match = self.metacontentregex.search(meta_tag)
+			if not content_match:
+				continue
+			content = content_match.group(1).decode("utf-8", errors="ignore").lower()
+			directives.update(directive.strip() for directive in content.split(","))
+		return directives
 
 	def find_links(self, msg, url, current_url, iframes: bool = False):
 		if iframes:

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ parser.add_argument('--report', action="store_true", default=False, required=Fal
 parser.add_argument('--images', action="store_true", default=False, required=False, help="Add image to sitemap.xml (see https://support.google.com/webmasters/answer/178636?hl=en)")
 parser.add_argument('--fetch-iframes', action="store_true", default=False, required=False, help="Fetch iframes' content when generating sitemap")
 parser.add_argument('--resume', action="store_true", default=False, required=False, help="Resume an interrupted crawl by reading already-crawled urls back out of --output, skipping them, and periodically saving progress there again (also on interrupt) so it can be resumed again if needed.")
-parser.add_argument('--respect-noindex', action="store_true", default=False, required=False, help="Exclude pages containing a <meta name=\"robots\" content=\"noindex\"> tag from the output sitemap. A page with a nofollow directive will still be included, but links found on it won't be followed.")
+parser.add_argument('--no-respect-noindex', action="store_false", default=True, required=False, dest='respect_noindex', help="Include pages containing a <meta name=\"robots\" content=\"noindex\"> tag in the output sitemap instead of excluding them.")
 
 group = parser.add_mutually_exclusive_group()
 group.add_argument('--config', action="store", default=None, help="Configuration file in json format")

--- a/main.py
+++ b/main.py
@@ -21,6 +21,7 @@ parser.add_argument('--report', action="store_true", default=False, required=Fal
 parser.add_argument('--images', action="store_true", default=False, required=False, help="Add image to sitemap.xml (see https://support.google.com/webmasters/answer/178636?hl=en)")
 parser.add_argument('--fetch-iframes', action="store_true", default=False, required=False, help="Fetch iframes' content when generating sitemap")
 parser.add_argument('--resume', action="store_true", default=False, required=False, help="Resume an interrupted crawl by reading already-crawled urls back out of --output, skipping them, and periodically saving progress there again (also on interrupt) so it can be resumed again if needed.")
+parser.add_argument('--respect-noindex', action="store_true", default=False, required=False, help="Exclude pages containing a <meta name=\"robots\" content=\"noindex\"> tag from the output sitemap. A page with a nofollow directive will still be included, but links found on it won't be followed.")
 
 group = parser.add_mutually_exclusive_group()
 group.add_argument('--config', action="store", default=None, help="Configuration file in json format")


### PR DESCRIPTION
## Summary
- Closes #86
- Excluding pages with `<meta name="robots" content="noindex">` from the generated sitemap is now the **default** behavior; links found on those pages are still crawled (since `noindex` doesn't imply `nofollow`)
- A `nofollow` directive on a page stops links found on that page from being followed, without excluding the page itself
- Added `--no-respect-noindex` to opt out and include noindex pages in the sitemap anyway (follows the same convention as `--no-sort`)
- Documents the new behavior/flag in the README

## Test plan
- [x] `python3 -m py_compile crawler.py main.py`
- [x] Manual smoke test against a local HTTP server with pages combining `noindex`/`nofollow` meta tags, confirming: the `noindex` page itself is excluded from the sitemap by default but its links are still crawled; the `nofollow` page itself is included but its links are not followed
- [ ] Manual verification against a real site with noindex pages
