### PR TITLE
Exclude canonicalized pages from the sitemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,13 @@ $ python3 main.py --domain https://blog.lesite.us --as-index --output sitemap.xm
 $ python3 main.py --domain https://blog.lesite.us --output sitemap.xml --no-respect-noindex
 ```
 
+#### Canonical tags
+
+***By default, pages whose `<link rel="canonical" href="...">` tag points to a different URL are excluded from the output sitemap, since the canonical page is the one that should be indexed. Pass `--no-respect-canonical` to include canonicalized pages in the sitemap anyway:***
+```
+$ python3 main.py --domain https://blog.lesite.us --output sitemap.xml --no-respect-canonical
+```
+
 #### Resume an interrupted crawl
 ***Large crawls can take a long time and may get interrupted (Ctrl+C, a crash, a network drop). Pass `--resume` to periodically save crawl progress into `--output` itself, including on interrupt, instead of a separate file. Re-running the exact same command afterwards continues from that file instead of starting over:***
 ```

--- a/crawler.py
+++ b/crawler.py
@@ -66,6 +66,9 @@ class Crawler:
 	metaregex = re.compile(b'<meta\\s+[^>]*>', re.IGNORECASE)
 	metanameregex = re.compile(b'name=[\'"](.*?)[\'"]', re.IGNORECASE)
 	metacontentregex = re.compile(b'content=[\'"](.*?)[\'"]', re.IGNORECASE)
+	linktagregex = re.compile(b'<link\\s+[^>]*>', re.IGNORECASE)
+	linkrelregex = re.compile(b'rel=[\'"](.*?)[\'"]', re.IGNORECASE)
+	linkhrefregex = re.compile(b'href=[\'"](.*?)[\'"]', re.IGNORECASE)
 
 	rp = None
 	response_code=defaultdict(int)
@@ -80,7 +83,7 @@ class Crawler:
 				 report=False ,domain="", exclude=[], skipext=[], drop=[],
 				 debug=False, verbose=False, images=False, auth=False, as_index=False,
 				 fetch_iframes=False, sort_alphabetically=True, user_agent='*', resume=False,
-				 respect_noindex=True):
+				 respect_noindex=True, respect_canonical=True):
 		self.num_workers   = num_workers
 		self.parserobots   = parserobots
 		self.user_agent    = user_agent
@@ -99,6 +102,7 @@ class Crawler:
 		self.sort_alphabetically = sort_alphabetically
 		self.resume        = resume
 		self.respect_noindex = respect_noindex
+		self.respect_canonical = respect_canonical
 
 		if self.debug:
 			log_level = logging.DEBUG
@@ -345,18 +349,26 @@ class Crawler:
 					image_caption = f"<image:caption>{self.htmlspecialchars(caption)}</image:caption>" if caption else ""
 					image_list = f"{image_list}<image:image><image:loc>{self.htmlspecialchars(image_link)}</image:loc>{image_title}{image_caption}</image:image>"
 
+		# Note: that if there was a redirect, `final_url` may be different than
+		#       `current_url`, and avoid not parseable content
+		final_url = response.geturl() if response is not None else current_url
+
+		# A canonical tag pointing to a different URL means this page is not the
+		# canonical version, so it shouldn't be indexed under its own URL
+		canonical_url = self.get_canonical_url(msg, final_url) if self.respect_canonical else None
+		is_canonicalized_elsewhere = canonical_url is not None and self.clean_link(canonical_url) != self.clean_link(final_url)
+
 		# Only add to sitemap URLs with same domain as the site being indexed
 		if url.netloc == self.target_domain:
 			if "noindex" in meta_robots_directives:
 				logging.debug(f"Skipping {current_url} from sitemap, noindex meta tag found.")
+			elif is_canonicalized_elsewhere:
+				logging.debug(f"Skipping {current_url} from sitemap, canonical tag points to {canonical_url}.")
 			else:
 				# Last mod fetched ?
 				lastmod = ""
 				if date:
 					lastmod = "<lastmod>"+date.strftime('%Y-%m-%dT%H:%M:%S+00:00')+"</lastmod>"
-				# Note: that if there was a redirect, `final_url` may be different than
-				#       `current_url`, and avoid not parseable content
-				final_url = response.geturl() if response is not None else current_url
 				url_string = "<url><loc>"+self.htmlspecialchars(final_url)+"</loc>" + lastmod + image_list + "</url>"
 				self.url_strings_to_output.append(url_string)
 		# If the URL has a different domain than the site being indexed, this was reached through an iframe
@@ -402,6 +414,22 @@ class Crawler:
 			content = content_match.group(1).decode("utf-8", errors="ignore").lower()
 			directives.update(directive.strip() for directive in content.split(","))
 		return directives
+
+	def get_canonical_url(self, msg, base_url):
+		# Returns the absolute URL from <link rel="canonical" href="..."> on the
+		# page, if any, resolved against base_url in case href is relative.
+		for link_tag in self.linktagregex.findall(msg):
+			rel_match = self.linkrelregex.search(link_tag)
+			if not rel_match or rel_match.group(1).decode("utf-8", errors="ignore").strip().lower() != "canonical":
+				continue
+			href_match = self.linkhrefregex.search(link_tag)
+			if not href_match:
+				continue
+			href = href_match.group(1).decode("utf-8", errors="ignore").strip()
+			if not href:
+				continue
+			return urljoin(base_url, href)
+		return None
 
 	def find_links(self, msg, url, current_url, iframes: bool = False):
 		if iframes:

--- a/main.py
+++ b/main.py
@@ -22,6 +22,7 @@ parser.add_argument('--images', action="store_true", default=False, required=Fal
 parser.add_argument('--fetch-iframes', action="store_true", default=False, required=False, help="Fetch iframes' content when generating sitemap")
 parser.add_argument('--resume', action="store_true", default=False, required=False, help="Resume an interrupted crawl by reading already-crawled urls back out of --output, skipping them, and periodically saving progress there again (also on interrupt) so it can be resumed again if needed.")
 parser.add_argument('--no-respect-noindex', action="store_false", default=True, required=False, dest='respect_noindex', help="Include pages containing a <meta name=\"robots\" content=\"noindex\"> tag in the output sitemap instead of excluding them.")
+parser.add_argument('--no-respect-canonical', action="store_false", default=True, required=False, dest='respect_canonical', help="Include pages whose <link rel=\"canonical\"> tag points to a different URL in the output sitemap instead of excluding them.")
 
 group = parser.add_mutually_exclusive_group()
 group.add_argument('--config', action="store", default=None, help="Configuration file in json format")


### PR DESCRIPTION
## Summary
- Closes #78
- Pages whose `<link rel="canonical" href="...">` tag points to a different URL are now excluded from the output sitemap by default, since the canonical page is the one that should be indexed (per Google's [sitemap guidance](https://developers.google.com/search/docs/advanced/sitemaps/build-sitemap))
- Links found on a canonicalized-away page are still crawled, so pages only reachable through it aren't missed
- Self-referencing canonical tags (the common case) don't exclude the page
- Added `--no-respect-canonical` to opt out and include canonicalized pages in the sitemap anyway (same convention as `--no-respect-noindex`)
- Documents the new behavior/flag in the README

## Test plan
- [x] `python3 -m py_compile crawler.py main.py`
- [x] Manual smoke test against a local HTTP server with pages combining self-referencing, same-domain, and cross-domain canonical tags, confirming: pages canonicalized elsewhere are excluded from the sitemap while their links are still crawled; self-referencing and non-canonical pages are included
- [x] Manual verification against a real site with canonicalized pages


---
_Generated by [Claude Code](https://claude.ai/code/session_01AKDzcqdmXCLUWr875HBRg3)_