### PR TITLE
Fix UnicodeEncodeError when crawling URLs with non-ASCII characters

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -7,12 +7,13 @@ import mimetypes
 import os
 import re
 import signal
+import string
 import sys
 from collections import defaultdict
 from copy import copy
 from datetime import datetime
 from urllib.error import HTTPError
-from urllib.parse import urljoin, urlsplit, urlunsplit
+from urllib.parse import quote, urljoin, urlsplit, urlunsplit
 from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 from urllib.robotparser import RobotFileParser
@@ -226,6 +227,12 @@ class Crawler:
 
 
 	def __crawl(self, current_url):
+		# Percent-encode any non-ASCII characters (e.g. raw unicode in the path)
+		# so the request line, which http.client requires to be ASCII, doesn't
+		# raise a UnicodeEncodeError. Already-encoded/reserved/punctuation
+		# characters are left untouched, so this is a no-op for plain URLs.
+		current_url = quote(current_url, safe=string.printable)
+
 		url = urlparse(current_url)
 		logging.info(f"Crawling #{self.num_crawled}: {url.geturl()}")
 		self.num_crawled += 1


### PR DESCRIPTION
## Summary
- Closes #79
- URLs containing raw unicode characters (e.g. `https://example.com/html/NPC掉落書籍.html`) raised `UnicodeEncodeError: 'ascii' codec can't encode characters...`, since `http.client`'s request line must be ASCII
- `crawler.py`'s `__crawl()` now percent-encodes `current_url` with `urllib.parse.quote(current_url, safe=string.printable)` before opening the request. Punctuation/reserved characters (already in `string.printable`) — and any URL that's already properly percent-encoded — pass through unchanged, so this only affects raw non-ASCII characters

## Test plan
- [x] Reproduced the exact error from the issue against a local test server with a non-ASCII filename, confirmed it disappears with this fix
- [x] Confirmed the crawled unicode page is correctly percent-encoded in the resulting sitemap `<loc>` entry
- [x] Confirmed plain ASCII URLs are unaffected (no double-encoding of existing `%XX` sequences or `/`, `?`, `=`, `&`, etc.)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AKDzcqdmXCLUWr875HBRg3)_